### PR TITLE
Update gamedata for TF2 version 7695204 (2022-12-02)

### DIFF
--- a/plugins/tf2-reverts/gamedata/reverts.txt
+++ b/plugins/tf2-reverts/gamedata/reverts.txt
@@ -16,20 +16,20 @@
 		{
 			"CTFWeaponBase::PrimaryAttack"
 			{
-				"linux" "289"
-				"windows" "283"
+				"linux" "292"
+				"windows" "286"
 			}
 			
 			"CTFWeaponBase::SecondaryAttack"
 			{
-				"linux" "290"
-				"windows" "284"
+				"linux" "293"
+				"windows" "287"
 			}
 			
 			"CTFBaseRocket::GetRadius"
 			{
-				"linux" "241"
-				"windows" "240"
+				"linux" "244"
+				"windows" "243"
 			}
 		}
 		


### PR DESCRIPTION
Brings gamedata up to date with the recent TF2 release.

(Note that there may be breakages elsewhere in the plugin.  I'd suggest independently verifying that the gamedata works.)